### PR TITLE
Initialise RandomDelay's random values and prevent a hang if any of the values weren't a multiple of 8

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,8 @@ void Thread2Func()
 
 int main(int argc, char* argv[])
 {
+    RandomDelay::Initialize();
+    
     printf("is_lock_free: %s\n", flag.is_lock_free() ? "true" : "false");
     
     for (;;) {

--- a/randomdelay.cpp
+++ b/randomdelay.cpp
@@ -22,7 +22,7 @@ void RandomDelay::doBusyWork()
     do
     {
         i = g_randomValues[m_pos];
-        m_pos += m_wrap;
+        m_pos += m_step;
         if (m_pos >= m_wrap)
             m_pos -= m_wrap;
     }


### PR DESCRIPTION
This was initially just a typo fix for RandomDelay::m_step, but I realised after that RandomDelay::g_randomValues wasn't being initialised meaning that RandomDelay hasn't been living up to its name for all these years.